### PR TITLE
CC-31327 Fixed handling of company role permissions changes

### DIFF
--- a/src/SprykerShop/Yves/CompanyPage/Controller/CompanyRoleController.php
+++ b/src/SprykerShop/Yves/CompanyPage/Controller/CompanyRoleController.php
@@ -353,6 +353,12 @@ class CompanyRoleController extends AbstractCompanyController
             'companyRoleForm' => $companyRoleForm->createView(),
             'idCompanyRole' => $idCompanyRole,
             'permissions' => $this->getSelectablePermissionsList($idCompanyRole)->getPermissions(),
+            'companyRolePermissionAssignFormCloner' => $this->getFactory()->createFormCloner()->setForm(
+                $this->getFactory()->createCompanyPageFormFactory()->getCompanyRolePermissionAssignForm(),
+            ),
+            'companyRolePermissionUnassignFormCloner' => $this->getFactory()->createFormCloner()->setForm(
+                $this->getFactory()->createCompanyPageFormFactory()->getCompanyRolePermissionUnassignForm(),
+            ),
         ];
     }
 

--- a/src/SprykerShop/Yves/CompanyPage/Controller/CompanyRolePermissionController.php
+++ b/src/SprykerShop/Yves/CompanyPage/Controller/CompanyRolePermissionController.php
@@ -49,6 +49,16 @@ class CompanyRolePermissionController extends AbstractCompanyController
      */
     public function assignAction(Request $request): RedirectResponse
     {
+        $companyRolePermissionAssignForm = $this->getFactory()
+            ->createCompanyPageFormFactory()
+            ->getCompanyRolePermissionAssignForm()
+            ->handleRequest($request);
+        if (!$companyRolePermissionAssignForm->isSubmitted() || !$companyRolePermissionAssignForm->isValid()) {
+            $this->addErrorMessage(static::MESSAGE_ERROR_PERMISSION_SAVE_FAILED);
+
+            return $this->redirectResponseInternal(CompanyPageRouteProviderPlugin::ROUTE_NAME_COMPANY_ROLE);
+        }
+
         $idCompanyRole = $request->query->getInt('id-company-role');
         $idPermission = $request->query->getInt('id-permission');
 
@@ -73,6 +83,16 @@ class CompanyRolePermissionController extends AbstractCompanyController
      */
     public function unassignAction(Request $request): RedirectResponse
     {
+        $companyRolePermissionUnassignForm = $this->getFactory()
+            ->createCompanyPageFormFactory()
+            ->getCompanyRolePermissionUnassignForm()
+            ->handleRequest($request);
+        if (!$companyRolePermissionUnassignForm->isSubmitted() || !$companyRolePermissionUnassignForm->isValid()) {
+            $this->addErrorMessage(static::MESSAGE_ERROR_PERMISSION_SAVE_FAILED);
+
+            return $this->redirectResponseInternal(CompanyPageRouteProviderPlugin::ROUTE_NAME_COMPANY_ROLE);
+        }
+
         $idCompanyRole = $request->query->getInt('id-company-role');
         $idPermission = $request->query->getInt('id-permission');
 

--- a/src/SprykerShop/Yves/CompanyPage/Form/CompanyRolePermissionAssignForm.php
+++ b/src/SprykerShop/Yves/CompanyPage/Form/CompanyRolePermissionAssignForm.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerShop\Yves\CompanyPage\Form;
+
+use Spryker\Yves\Kernel\Form\AbstractType;
+
+class CompanyRolePermissionAssignForm extends AbstractType
+{
+}

--- a/src/SprykerShop/Yves/CompanyPage/Form/CompanyRolePermissionUnassignForm.php
+++ b/src/SprykerShop/Yves/CompanyPage/Form/CompanyRolePermissionUnassignForm.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerShop\Yves\CompanyPage\Form;
+
+use Spryker\Yves\Kernel\Form\AbstractType;
+
+class CompanyRolePermissionUnassignForm extends AbstractType
+{
+}

--- a/src/SprykerShop/Yves/CompanyPage/Form/FormFactory.php
+++ b/src/SprykerShop/Yves/CompanyPage/Form/FormFactory.php
@@ -176,7 +176,7 @@ class FormFactory extends AbstractFactory
     }
 
     /**
-     * @SuppressWarnings(PHPMD)
+     * @SuppressWarnings(\SprykerShop\Yves\CompanyPage\Form\PHPMD)
      *
      * @return \SprykerShop\Yves\CompanyPage\Form\DataProvider\CompanyBusinessUnitFormDataProvider
      */
@@ -199,7 +199,7 @@ class FormFactory extends AbstractFactory
     }
 
     /**
-     * @SuppressWarnings(PHPMD)
+     * @SuppressWarnings(\SprykerShop\Yves\CompanyPage\Form\PHPMD)
      *
      * @return \SprykerShop\Yves\CompanyPage\Form\DataProvider\CompanyUnitAddressFormDataProvider
      */
@@ -213,7 +213,7 @@ class FormFactory extends AbstractFactory
     }
 
     /**
-     * @SuppressWarnings(PHPMD)
+     * @SuppressWarnings(\SprykerShop\Yves\CompanyPage\Form\PHPMD)
      *
      * @return \SprykerShop\Yves\CompanyPage\Form\DataProvider\CompanyRoleDataProvider
      */
@@ -231,6 +231,22 @@ class FormFactory extends AbstractFactory
     public function getCompanyUserAccountForm(array $data = [], array $formOptions = []): FormInterface
     {
         return $this->getFormFactory()->create(CompanyUserAccountSelectorForm::class, $data, $formOptions);
+    }
+
+    /**
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    public function getCompanyRolePermissionAssignForm(): FormInterface
+    {
+        return $this->getFormFactory()->create(CompanyRolePermissionAssignForm::class);
+    }
+
+    /**
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    public function getCompanyRolePermissionUnassignForm(): FormInterface
+    {
+        return $this->getFormFactory()->create(CompanyRolePermissionUnassignForm::class);
     }
 
     /**

--- a/src/SprykerShop/Yves/CompanyPage/Theme/default/components/molecules/permission-table/permission-table.twig
+++ b/src/SprykerShop/Yves/CompanyPage/Theme/default/components/molecules/permission-table/permission-table.twig
@@ -7,6 +7,8 @@
 {% define data = {
     permissions: required,
     idCompanyRole: required,
+    companyRolePermissionAssignFormCloner: null,
+    companyRolePermissionUnassignFormCloner: null,
     actions: {
         configure: false,
         switch: false,
@@ -31,6 +33,7 @@
         <tbody>
         {% for permission in data.permissions %}
             {% set isAssigned = permission.idCompanyRole | default(false) %}
+            
             <tr>
                 <td>{{ permission.key | trans }}</td>
                 {% if data.actions.switch %}
@@ -58,13 +61,41 @@
                             {% if data.actions.switch %}
                                 <li class="menu__item">
                                     {% if isAssigned %}
-                                        <a href="{{ path('company/company-role-permission/unassign', {'id-permission': permission.idPermission, 'id-company-role': _view.idCompanyRole}) }}">
-                                            {{ 'company.account.company_role.permission.unassign' | trans }}
-                                        </a>
+                                        {% set companyRolePermissionUnassignForm = data.companyRolePermissionUnassignFormCloner.getForm.createView ?? null %}
+                                        {% set formAction = path('company/company-role-permission/unassign', {
+                                            'id-permission': permission.idPermission,
+                                            'id-company-role': data.idCompanyRole,
+                                        }) %}
+                                        {% set linkText = 'company.account.company_role.permission.unassign' | trans %}
+
+                                        {% if companyRolePermissionUnassignForm %}
+                                            {{ form_start(companyRolePermissionUnassignForm, { action: formAction }) }}
+                                                <button class="link" data-init-single-click>{{ linkText }}</button>
+                                            {{ form_end(companyRolePermissionUnassignForm) }}
+                                        {% else %}
+                                            <form name="company_role_permission_unassign_form" method="POST" action="{{ formAction }}">
+                                                <button class="link" data-init-single-click>{{ linkText }}</button>
+                                                <input type="hidden" name="company_role_permission_unassign_form[_token]" value="{{ csrf_token('company_role_permission_unassign_form') }}">
+                                            </form>
+                                        {% endif %}
                                     {% else %}
-                                        <a href="{{ path('company/company-role-permission/assign', {'id-permission': permission.idPermission, 'id-company-role': _view.idCompanyRole}) }}">
-                                            {{ 'company.account.company_role.permission.assign' | trans }}
-                                        </a>
+                                        {% set companyRolePermissionAssignForm = data.companyRolePermissionAssignFormCloner.getForm.createView ?? null %}
+                                        {% set formAction = path('company/company-role-permission/assign', {
+                                            'id-permission': permission.idPermission,
+                                            'id-company-role': data.idCompanyRole,
+                                        }) %}
+                                        {% set linkText = 'company.account.company_role.permission.assign' | trans %}
+
+                                        {% if companyRolePermissionAssignForm %}
+                                            {{ form_start(companyRolePermissionAssignForm, { action: formAction }) }}
+                                                <button class="link" data-init-single-click>{{ linkText }}</button>
+                                            {{ form_end(companyRolePermissionAssignForm) }}
+                                        {% else %}
+                                            <form name="company_role_permission_assign_form" method="POST" action="{{ formAction }}">
+                                                <button class="link" data-init-single-click>{{ linkText }}</button>
+                                                <input type="hidden" name="company_role_permission_assign_form[_token]" value="{{ csrf_token('company_role_permission_assign_form') }}">
+                                            </form>
+                                        {% endif %}
                                     {% endif %}
                                 </li>
                             {% endif %}

--- a/src/SprykerShop/Yves/CompanyPage/Theme/default/views/role-update/role-update.twig
+++ b/src/SprykerShop/Yves/CompanyPage/Theme/default/views/role-update/role-update.twig
@@ -4,6 +4,8 @@
     form: _view.companyRoleForm,
     permissions: _view.permissions,
     idCompanyRole: _view.idCompanyRole,
+    companyRolePermissionAssignFormCloner: _view.companyRolePermissionAssignFormCloner,
+    companyRolePermissionUnassignFormCloner: _view.companyRolePermissionUnassignFormCloner,
 
     title: 'company.account.company_role' | trans,
     activePage: 'role'
@@ -54,6 +56,8 @@
             data: {
                 permissions: data.permissions,
                 idCompanyRole: data.idCompanyRole,
+                companyRolePermissionAssignFormCloner: data.companyRolePermissionAssignFormCloner,
+                companyRolePermissionUnassignFormCloner: data.companyRolePermissionUnassignFormCloner,
                 actions: {
                     configure: true,
                     switch: true


### PR DESCRIPTION
- Developer(s): @AsonUnique

- Ticket: https://spryker.atlassian.net/browse/CC-31327

- Release Group: https://release.spryker.com/release-groups/view/5158

- PR Overview: https://release.spryker.com/release/pull-request-shop/2428

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CompanyPage           | patch                 |                       |

-----------------------------------------

#### Module CompanyPage

##### Change log

Improvements

- Introduced a new `companyRolePermissionAssignFormCloner` data property to the `role-update` view.
- Introduced a new `companyRolePermissionUnassignFormCloner` data property to the `role-update` view.
- Introduced a new `companyRolePermissionAssignFormCloner` data property to the `permission-table` molecule.
- Introduced a new `companyRolePermissionUnassignFormCloner` data property to the `permission-table` molecule.
- Adjusted `CompanyRoleController::updateAction()` to render a form for every company role permission assign/unassign action.
- Adjusted `CompanyRolePermissionController::assignAction()` to correctly handle the submitted form.
- Adjusted `CompanyRolePermissionController::unassignAction()` to correctly handle the submitted form.

BC breaking impact

- `CompanyRolePermissionController::assignAction()` now becomes POST only and must be called by `CompanyRolePermissionAssignForm` submit.
- `CompanyRolePermissionController::unassignAction()` now becomes POST only and must be called by `CompanyRolePermissionUnassignForm` submit.


